### PR TITLE
카카오 소셜 로그인 구현

### DIFF
--- a/src/main/java/today/seasoning/seasoning/user/controller/OauthController.java
+++ b/src/main/java/today/seasoning/seasoning/user/controller/OauthController.java
@@ -1,0 +1,27 @@
+package today.seasoning.seasoning.user.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import today.seasoning.seasoning.user.service.KakaoLoginService;
+
+@RestController
+@RequestMapping("/oauth")
+@RequiredArgsConstructor
+public class OauthController {
+
+	private final KakaoLoginService kakaoLoginService;
+
+	@GetMapping("/kakao/login")
+	public ResponseEntity<Void> kakaoLogin(@RequestParam("code") String authCode) {
+
+		String token = kakaoLoginService.handleKakaoLogin(authCode);
+
+		return ResponseEntity.ok()
+			.header("Authorization", token)
+			.build();
+	}
+}

--- a/src/main/java/today/seasoning/seasoning/user/domain/User.java
+++ b/src/main/java/today/seasoning/seasoning/user/domain/User.java
@@ -1,0 +1,50 @@
+package today.seasoning.seasoning.user.domain;
+
+import com.github.f4b6a3.tsid.TsidCreator;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import javax.persistence.UniqueConstraint;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import today.seasoning.seasoning.common.BaseTimeEntity;
+import today.seasoning.seasoning.common.enums.LoginType;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@Table(name = "user",
+	uniqueConstraints = {
+		@UniqueConstraint(name = "uix-email-login_type", columnNames = {"email", "login_type"})})
+public class User extends BaseTimeEntity {
+
+	@Id
+	private Long id;
+
+	@Column(nullable = false)
+	private String nickname;
+
+	private String profileImageUrl;
+
+	@Column(unique = true, nullable = false)
+	private String accountId;
+
+	@Column(nullable = false)
+	private String email;
+
+	@Column(name = "login_type", nullable = false)
+	@Enumerated(EnumType.STRING)
+	private LoginType loginType;
+
+	public User(String nickname, String profileImageUrl, String email, LoginType loginType) {
+		this.id = TsidCreator.getTsid().toLong();
+		this.nickname = nickname;
+		this.profileImageUrl = profileImageUrl;
+		this.accountId = TsidCreator.getTsid().toString(); // 최초 랜덤값
+		this.email = email;
+		this.loginType = loginType;
+	}
+}

--- a/src/main/java/today/seasoning/seasoning/user/domain/UserRepository.java
+++ b/src/main/java/today/seasoning/seasoning/user/domain/UserRepository.java
@@ -1,0 +1,7 @@
+package today.seasoning.seasoning.user.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+}

--- a/src/main/java/today/seasoning/seasoning/user/domain/UserRepository.java
+++ b/src/main/java/today/seasoning/seasoning/user/domain/UserRepository.java
@@ -1,7 +1,13 @@
 package today.seasoning.seasoning.user.domain;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import today.seasoning.seasoning.common.enums.LoginType;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
+	@Query("SELECT u FROM User u WHERE u.email = :email AND u.loginType = :loginType")
+	Optional<User> find(@Param("email") String email, @Param("loginType") LoginType loginType);
 }

--- a/src/main/java/today/seasoning/seasoning/user/dto/UserProfile.java
+++ b/src/main/java/today/seasoning/seasoning/user/dto/UserProfile.java
@@ -1,0 +1,13 @@
+package today.seasoning.seasoning.user.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class UserProfile {
+
+	private final String nickname;
+	private final String email;
+	private final String profileImageUrl;
+}

--- a/src/main/java/today/seasoning/seasoning/user/service/KakaoLoginService.java
+++ b/src/main/java/today/seasoning/seasoning/user/service/KakaoLoginService.java
@@ -1,0 +1,48 @@
+package today.seasoning.seasoning.user.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import today.seasoning.seasoning.common.enums.LoginType;
+import today.seasoning.seasoning.common.util.JwtUtil;
+import today.seasoning.seasoning.user.domain.User;
+import today.seasoning.seasoning.user.domain.UserRepository;
+import today.seasoning.seasoning.user.dto.UserProfile;
+import today.seasoning.seasoning.user.service.port.kakao.ExchangeKakaoAccessToken;
+import today.seasoning.seasoning.user.service.port.kakao.FetchKakaoUserProfile;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class KakaoLoginService {
+
+	private static final LoginType KAKAO_LOGIN_TYPE = LoginType.KAKAO;
+
+	private final ExchangeKakaoAccessToken exchangeKakaoAccessToken;
+	private final FetchKakaoUserProfile fetchKakaoUserProfile;
+	private final UserRepository userRepository;
+	private final JwtUtil jwtUtil;
+
+	@Transactional
+	public String handleKakaoLogin(String authorizationCode) {
+		String accessToken = exchangeKakaoAccessToken.doExchange(authorizationCode);
+
+		UserProfile userProfile = fetchKakaoUserProfile.doFetch(accessToken);
+
+		User user = userRepository.find(userProfile.getEmail(), KAKAO_LOGIN_TYPE)
+			.orElseGet(() -> registerUser(userProfile));
+
+		return jwtUtil.createToken(user.getId(), KAKAO_LOGIN_TYPE);
+	}
+
+	private User registerUser(UserProfile userProfile) {
+		User user = new User(
+			userProfile.getNickname(),
+			userProfile.getProfileImageUrl(),
+			userProfile.getEmail(),
+			KAKAO_LOGIN_TYPE);
+
+		return userRepository.save(user);
+	}
+}

--- a/src/main/java/today/seasoning/seasoning/user/service/port/kakao/ExchangeKakaoAccessToken.java
+++ b/src/main/java/today/seasoning/seasoning/user/service/port/kakao/ExchangeKakaoAccessToken.java
@@ -1,0 +1,6 @@
+package today.seasoning.seasoning.user.service.port.kakao;
+
+public interface ExchangeKakaoAccessToken {
+
+	String doExchange(String authorizationCode);
+}

--- a/src/main/java/today/seasoning/seasoning/user/service/port/kakao/ExchangeKakaoAccessTokenImpl.java
+++ b/src/main/java/today/seasoning/seasoning/user/service/port/kakao/ExchangeKakaoAccessTokenImpl.java
@@ -1,0 +1,81 @@
+package today.seasoning.seasoning.user.service.port.kakao;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+import today.seasoning.seasoning.common.exception.CustomException;
+
+@Slf4j
+@Component
+public class ExchangeKakaoAccessTokenImpl implements ExchangeKakaoAccessToken {
+
+	@Value("${KAKAO_REST_API_KEY}")
+	private String restApiKey;
+
+	@Value("${KAKAO_CLIENT_SECRET}")
+	private String clientSecret;
+
+	@Value("${KAKAO_LOGIN_REDIRECT_URL}")
+	private String redirectURI;
+
+	@Value("${KAKAO_LOGIN_ENDPOINT}")
+	private String endPoint;
+
+	@Override
+	public String doExchange(String authorizationCode) {
+		try {
+			return exchangeAccessToken(authorizationCode);
+		} catch (IOException e) {
+			log.error("카카오 액세스 토큰 교환 오류");
+			throw new CustomException(HttpStatus.INTERNAL_SERVER_ERROR, "카카오 로그인 실패");
+		}
+	}
+
+	private String exchangeAccessToken(String authorizationCode) throws JsonProcessingException {
+		HttpEntity<MultiValueMap<String, String>> httpEntity = createLoginHttpEntity(
+			authorizationCode);
+		RestTemplate restTemplate = new RestTemplate();
+		ObjectMapper objectMapper = new ObjectMapper();
+
+		ResponseEntity<String> responseEntity = restTemplate.exchange(
+			endPoint,
+			HttpMethod.POST,
+			httpEntity,
+			String.class);
+
+		if (responseEntity.getBody() == null || responseEntity.getBody().isBlank()) {
+			return "";
+		}
+
+		return objectMapper.readTree(responseEntity.getBody())
+			.get("access_token")
+			.asText();
+	}
+
+	private HttpEntity<MultiValueMap<String, String>> createLoginHttpEntity(
+		String authorizationCode) {
+		HttpHeaders headers = new HttpHeaders();
+		headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+		MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+		body.add("grant_type", "authorization_code");
+		body.add("client_id", restApiKey);
+		body.add("redirect_uri", redirectURI);
+		body.add("code", authorizationCode);
+		body.add("client_secret", clientSecret);
+
+		return new HttpEntity<>(body, headers);
+	}
+}

--- a/src/main/java/today/seasoning/seasoning/user/service/port/kakao/FetchKakaoUserProfile.java
+++ b/src/main/java/today/seasoning/seasoning/user/service/port/kakao/FetchKakaoUserProfile.java
@@ -1,0 +1,8 @@
+package today.seasoning.seasoning.user.service.port.kakao;
+
+import today.seasoning.seasoning.user.dto.UserProfile;
+
+public interface FetchKakaoUserProfile {
+
+	UserProfile doFetch(String accessToken);
+}

--- a/src/main/java/today/seasoning/seasoning/user/service/port/kakao/FetchKakaoUserProfileImpl.java
+++ b/src/main/java/today/seasoning/seasoning/user/service/port/kakao/FetchKakaoUserProfileImpl.java
@@ -1,0 +1,80 @@
+package today.seasoning.seasoning.user.service.port.kakao;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+import today.seasoning.seasoning.common.exception.CustomException;
+import today.seasoning.seasoning.user.dto.UserProfile;
+
+@Component
+public class FetchKakaoUserProfileImpl implements FetchKakaoUserProfile {
+
+	@Value("${KAKAO_USER_PROFILE_ENDPOINT}")
+	private String endPoint;
+
+	public UserProfile doFetch(String accessToken) {
+		try {
+			return fetchUserProfile(accessToken);
+		} catch (Exception e) {
+			throw new CustomException(HttpStatus.INTERNAL_SERVER_ERROR, "카카오 사용자 프로필 오류");
+		}
+	}
+
+	private UserProfile fetchUserProfile(String accessToken) throws JsonProcessingException {
+		RestTemplate restTemplate = new RestTemplate();
+		ObjectMapper objectMapper = new ObjectMapper();
+
+		HttpEntity<Void> httpEntity = createProfileHttpEntity(accessToken);
+
+		ResponseEntity<String> responseEntity = restTemplate.exchange(
+			endPoint,
+			HttpMethod.GET,
+			httpEntity,
+			String.class);
+
+		JsonNode jsonNode = objectMapper.readTree(responseEntity.getBody());
+
+		String nickname = parseNickname(jsonNode);
+		String email = parseEmail(jsonNode);
+		String profileImageUrl = parseProfileImageUrl(jsonNode);
+
+		return new UserProfile(nickname, email, profileImageUrl);
+	}
+
+	private HttpEntity<Void> createProfileHttpEntity(String accessToken) {
+		HttpHeaders headers = new HttpHeaders();
+
+		headers.add("Authorization", "Bearer " + accessToken);
+		headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+
+		return new HttpEntity<>(headers);
+	}
+
+	private String parseNickname(JsonNode jsonNode) {
+		return jsonNode.get("kakao_account")
+			.get("profile")
+			.get("nickname")
+			.asText();
+	}
+
+	private String parseEmail(JsonNode jsonNode) {
+		return jsonNode.get("kakao_account")
+			.get("email")
+			.asText();
+	}
+
+	private String parseProfileImageUrl(JsonNode jsonNode) {
+		return jsonNode.get("kakao_account")
+			.get("profile")
+			.get("profile_image_url")
+			.asText();
+	}
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,6 +1,6 @@
 spring:
   jpa:
-    database-platform: org.hibernate.dialect.MySQLDialect
+    database-platform: org.hibernate.dialect.MySQL5InnoDBDialect
     open-in-view: false
     hibernate:
       ddl-auto: update

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,6 +1,6 @@
 spring:
   jpa:
-    database-platform: org.hibernate.dialect.MySQLDialect
+    database-platform: org.hibernate.dialect.MySQL5InnoDBDialect
     open-in-view: false
     hibernate:
       ddl-auto: validate


### PR DESCRIPTION
## 📟 연결된 이슈
close #7 

## 👷 작업한 내용
- 데이터베이스 Dialect 호환성 문제 해결
- 회원 엔티티 작성
- 카카오 소셜 로그인 구현
  - 비회원이 카카로 로그인 시, 자동으로 회원가입 되도록 구현 