### PR TITLE
JWT 필터 기능 변경

### DIFF
--- a/src/main/java/today/seasoning/seasoning/common/UserPrincipal.java
+++ b/src/main/java/today/seasoning/seasoning/common/UserPrincipal.java
@@ -3,17 +3,37 @@ package today.seasoning.seasoning.common;
 import java.io.Serializable;
 import lombok.Getter;
 import today.seasoning.seasoning.common.enums.LoginType;
+import today.seasoning.seasoning.user.domain.User;
 
 @Getter
 public class UserPrincipal implements Serializable {
 
-    private static final long serialVersionUID = 1L;
+	private static final long serialVersionUID = 1L;
 
-    private final Long id;
-    private final LoginType loginType;
+	private final Long id;
+	private final String nickname;
+	private final String profileImageUrl;
+	private final String accountId;
+	private final String email;
+	private final LoginType loginType;
 
-    public UserPrincipal(Long id, LoginType loginType) {
-        this.id = id;
-        this.loginType = loginType;
-    }
+	public UserPrincipal(Long id, String nickname, String profileImageUrl, String accountId,
+		String email, LoginType loginType) {
+		this.id = id;
+		this.nickname = nickname;
+		this.profileImageUrl = profileImageUrl;
+		this.accountId = accountId;
+		this.email = email;
+		this.loginType = loginType;
+	}
+
+	public static UserPrincipal builder(User user) {
+		return new UserPrincipal(
+			user.getId(),
+			user.getNickname(),
+			user.getProfileImageUrl(),
+			user.getAccountId(),
+			user.getEmail(),
+			user.getLoginType());
+	}
 }

--- a/src/main/java/today/seasoning/seasoning/common/config/SecurityConfig.java
+++ b/src/main/java/today/seasoning/seasoning/common/config/SecurityConfig.java
@@ -8,21 +8,20 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import today.seasoning.seasoning.common.util.JwtUtil;
 
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
 
-	private final JwtUtil jwtUtil;
+	private final JwtFilter jwtFilter;
 
 	@Bean
 	public SecurityFilterChain securityFilterChain(HttpSecurity httpSecurity) throws Exception {
 		httpSecurity
 			.csrf(AbstractHttpConfigurer::disable)
 			.cors().and()
-			.addFilterBefore(new JwtFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class);
+			.addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
 
 		return httpSecurity.build();
 	}


### PR DESCRIPTION
## 📟 연결된 이슈
close #21 

## 👷 작업한 내용
- 토큰에 담긴 회원 식별자의 유효성을 검증하는 로직을 JWT 필터에서 수행하도록 변경
- UserPrincipal에 저장하는 회원 정보 유형 추가

## 🚨 참고 사항
- 거의 모든 로직에서 회원 식별자의 유효성 검증이 필요하므로, 이를 필터로 옮겨 중복을 제거
- 기존에 스프링 시큐리티를 공부한 적이 없어 주먹구구식으로 구현했는데, 알고보니 Spring Boot OAuth 2.0 Client 라는 것이 따로 있었다.
  - 확실히 현재 방식보다 훨씬 더 기능도 많고 유연하게 흐름 제어가 가능하다.
  - 하지만 시간적 여유가 없기 때문에, 우선은 현재 방식대로 진행하고 시간이 남는다면 적용해 보기로 했다.