### PR TITLE
기록장 등록 기능 구현

### DIFF
--- a/src/main/java/today/seasoning/seasoning/SeasoningApplication.java
+++ b/src/main/java/today/seasoning/seasoning/SeasoningApplication.java
@@ -3,7 +3,9 @@ package today.seasoning.seasoning;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @EnableJpaAuditing
 @SpringBootApplication
 public class SeasoningApplication {

--- a/src/main/java/today/seasoning/seasoning/article/controller/ArticleController.java
+++ b/src/main/java/today/seasoning/seasoning/article/controller/ArticleController.java
@@ -1,0 +1,37 @@
+package today.seasoning.seasoning.article.controller;
+
+import javax.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import today.seasoning.seasoning.article.dto.RegisterArticleCommand;
+import today.seasoning.seasoning.article.dto.RegisterArticleWebRequest;
+import today.seasoning.seasoning.article.service.RegisterArticleService;
+import today.seasoning.seasoning.common.UserPrincipal;
+import today.seasoning.seasoning.common.util.TsidUtil;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/article")
+public class ArticleController {
+
+	private final RegisterArticleService registerArticleService;
+
+	@PostMapping
+	public ResponseEntity<String> registerArticle(@AuthenticationPrincipal UserPrincipal principal,
+		@RequestBody @Valid RegisterArticleWebRequest webRequest) {
+
+		RegisterArticleCommand command = new RegisterArticleCommand(principal.getId(),
+			webRequest.getIsPublic(),
+			webRequest.getContents(),
+			webRequest.getImages());
+
+		Long registeredArticleId = registerArticleService.doRegister(command);
+
+		return ResponseEntity.ok(TsidUtil.toString(registeredArticleId));
+	}
+}

--- a/src/main/java/today/seasoning/seasoning/article/domain/Article.java
+++ b/src/main/java/today/seasoning/seasoning/article/domain/Article.java
@@ -1,0 +1,60 @@
+package today.seasoning.seasoning.article.domain;
+
+import java.util.List;
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.Lob;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Check;
+import today.seasoning.seasoning.common.util.TsidUtil;
+import today.seasoning.seasoning.user.domain.User;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Article {
+
+	@Id
+	@Column(name = "article_id")
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id")
+	private User user;
+
+	@Column(name = "is_public")
+	private boolean isPublic;
+
+	@Check(constraints = "created_year >= 2023 AND created_year < 2100")
+	@Column(name = "created_year", nullable = false, columnDefinition = "INTEGER CHECK (created_year >= 2023 AND created_year < 2100)")
+	private int createdYear;
+
+	@Check(constraints = "created_term >= 1 AND created_term <= 24")
+	@Column(name = "created_term", nullable = false, columnDefinition = "INTEGER CHECK (created_term >= 1 AND created_term <= 24)")
+	private int createdTerm;
+
+	@Lob
+	private String contents;
+
+	@OneToMany(mappedBy = "article", cascade = CascadeType.REMOVE)
+	private List<ArticleImage> articleImages;
+
+	@OneToMany(mappedBy = "article", cascade = CascadeType.REMOVE)
+	private List<ArticleLike> articleLikes;
+
+	public Article(User user, boolean isPublic, int createdYear, int createdTerm, String contents) {
+		this.id = TsidUtil.createLong();
+		this.user = user;
+		this.isPublic = isPublic;
+		this.createdYear = createdYear;
+		this.createdTerm = createdTerm;
+		this.contents = contents;
+	}
+}

--- a/src/main/java/today/seasoning/seasoning/article/domain/ArticleImage.java
+++ b/src/main/java/today/seasoning/seasoning/article/domain/ArticleImage.java
@@ -17,21 +17,21 @@ public class ArticleImage {
 	@Id
 	private Long id;
 
-	@Check(constraints = "sequence >= 1")
-	@Column(nullable = false)
-	private int sequence;
-
-	@Column(nullable = false)
-	private String url;
-
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "article_id")
 	private Article article;
 
-	public ArticleImage(int sequence, String url, Article article) {
+	@Column(nullable = false)
+	private String url;
+
+	@Check(constraints = "sequence >= 1")
+	@Column(nullable = false)
+	private int sequence;
+
+	public ArticleImage(Article article, String url, int sequence) {
 		this.id = TsidUtil.createLong();
-		this.sequence = sequence;
-		this.url = url;
 		this.article = article;
+		this.url = url;
+		this.sequence = sequence;
 	}
 }

--- a/src/main/java/today/seasoning/seasoning/article/domain/ArticleImage.java
+++ b/src/main/java/today/seasoning/seasoning/article/domain/ArticleImage.java
@@ -1,0 +1,37 @@
+package today.seasoning.seasoning.article.domain;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Check;
+import today.seasoning.seasoning.common.util.TsidUtil;
+
+@Entity
+@NoArgsConstructor
+public class ArticleImage {
+
+	@Id
+	private Long id;
+
+	@Check(constraints = "sequence >= 1")
+	@Column(nullable = false)
+	private int sequence;
+
+	@Column(nullable = false)
+	private String url;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "article_id")
+	private Article article;
+
+	public ArticleImage(int sequence, String url, Article article) {
+		this.id = TsidUtil.createLong();
+		this.sequence = sequence;
+		this.url = url;
+		this.article = article;
+	}
+}

--- a/src/main/java/today/seasoning/seasoning/article/domain/ArticleImageRepository.java
+++ b/src/main/java/today/seasoning/seasoning/article/domain/ArticleImageRepository.java
@@ -1,0 +1,7 @@
+package today.seasoning.seasoning.article.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ArticleImageRepository extends JpaRepository<ArticleImage, Long> {
+
+}

--- a/src/main/java/today/seasoning/seasoning/article/domain/ArticleLike.java
+++ b/src/main/java/today/seasoning/seasoning/article/domain/ArticleLike.java
@@ -1,0 +1,38 @@
+package today.seasoning.seasoning.article.domain;
+
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import javax.persistence.UniqueConstraint;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import today.seasoning.seasoning.common.util.TsidUtil;
+import today.seasoning.seasoning.user.domain.User;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@Table(name = "article_like",
+	uniqueConstraints = {@UniqueConstraint(columnNames = {"article_id", "user_id"})})
+public class ArticleLike {
+
+	@Id
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "article_id")
+	private Article article;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id")
+	private User user;
+
+	public ArticleLike(Article article, User user) {
+		this.id = TsidUtil.createLong();
+		this.article = article;
+		this.user = user;
+	}
+}

--- a/src/main/java/today/seasoning/seasoning/article/domain/ArticleLikeRepository.java
+++ b/src/main/java/today/seasoning/seasoning/article/domain/ArticleLikeRepository.java
@@ -1,0 +1,7 @@
+package today.seasoning.seasoning.article.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ArticleLikeRepository extends JpaRepository<ArticleLike, Long> {
+
+}

--- a/src/main/java/today/seasoning/seasoning/article/domain/ArticleRepository.java
+++ b/src/main/java/today/seasoning/seasoning/article/domain/ArticleRepository.java
@@ -1,0 +1,7 @@
+package today.seasoning.seasoning.article.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ArticleRepository extends JpaRepository<Article, Long> {
+
+}

--- a/src/main/java/today/seasoning/seasoning/article/dto/ArticleImageDto.java
+++ b/src/main/java/today/seasoning/seasoning/article/dto/ArticleImageDto.java
@@ -1,0 +1,21 @@
+package today.seasoning.seasoning.article.dto;
+
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class ArticleImageDto {
+
+	@NotNull
+	@Min(value = 1)
+	private Integer sequence;
+
+	@NotBlank
+	private String url;
+}

--- a/src/main/java/today/seasoning/seasoning/article/dto/RegisterArticleCommand.java
+++ b/src/main/java/today/seasoning/seasoning/article/dto/RegisterArticleCommand.java
@@ -1,0 +1,21 @@
+package today.seasoning.seasoning.article.dto;
+
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class RegisterArticleCommand {
+
+	private final Long userId;
+	private final boolean isPublic;
+	private final String contents;
+	private final List<ArticleImageDto> articleImages;
+
+	public RegisterArticleCommand(Long userId, boolean isPublic, String contents,
+		List<ArticleImageDto> articleImages) {
+		this.userId = userId;
+		this.isPublic = isPublic;
+		this.contents = contents;
+		this.articleImages = articleImages;
+	}
+}

--- a/src/main/java/today/seasoning/seasoning/article/dto/RegisterArticleWebRequest.java
+++ b/src/main/java/today/seasoning/seasoning/article/dto/RegisterArticleWebRequest.java
@@ -1,0 +1,25 @@
+package today.seasoning.seasoning.article.dto;
+
+import java.util.List;
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class RegisterArticleWebRequest {
+
+	@NotNull
+	private Boolean isPublic;
+
+	@NotNull
+	private String contents;
+
+	@Valid
+	@NotNull
+	private List<ArticleImageDto> images;
+}

--- a/src/main/java/today/seasoning/seasoning/article/service/RegisterArticleService.java
+++ b/src/main/java/today/seasoning/seasoning/article/service/RegisterArticleService.java
@@ -1,0 +1,67 @@
+package today.seasoning.seasoning.article.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import today.seasoning.seasoning.article.domain.Article;
+import today.seasoning.seasoning.article.domain.ArticleImage;
+import today.seasoning.seasoning.article.domain.ArticleImageRepository;
+import today.seasoning.seasoning.article.domain.ArticleRepository;
+import today.seasoning.seasoning.article.dto.ArticleImageDto;
+import today.seasoning.seasoning.article.dto.RegisterArticleCommand;
+import today.seasoning.seasoning.common.exception.CustomException;
+import today.seasoning.seasoning.common.util.SolarTermUtil;
+import today.seasoning.seasoning.user.domain.User;
+import today.seasoning.seasoning.user.domain.UserRepository;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class RegisterArticleService {
+
+	private final UserRepository userRepository;
+	private final ArticleRepository articleRepository;
+	private final ArticleImageRepository articleImageRepository;
+
+	public Long doRegister(RegisterArticleCommand command) {
+		verifySolarTerm();
+
+		Article article = createArticle(command);
+
+		articleRepository.save(article);
+		registerArticleImages(article, command);
+
+		return article.getId();
+	}
+
+	private void verifySolarTerm() {
+		if (SolarTermUtil.getCurrentTerm() == -1) {
+			throw new CustomException(HttpStatus.FORBIDDEN, "기록장이 열리지 않았습니다.");
+		}
+	}
+
+	private Article createArticle(RegisterArticleCommand command) {
+		User user = userRepository.findById(command.getUserId()).get();
+
+		return new Article(user,
+			command.isPublic(),
+			SolarTermUtil.getCurrentYear(),
+			SolarTermUtil.getCurrentTerm(),
+			command.getContents());
+	}
+
+	private void registerArticleImages(Article article, RegisterArticleCommand command) {
+		command.getArticleImages()
+			.stream()
+			.map(dto -> createArticleImage(article, dto))
+			.forEach(articleImageRepository::save);
+	}
+
+	private ArticleImage createArticleImage(Article article, ArticleImageDto dto) {
+		return new ArticleImage(article,
+			dto.getUrl(),
+			dto.getSequence());
+	}
+
+}

--- a/src/main/java/today/seasoning/seasoning/common/util/SeasonalTermUtil.java
+++ b/src/main/java/today/seasoning/seasoning/common/util/SeasonalTermUtil.java
@@ -1,0 +1,206 @@
+package today.seasoning.seasoning.common.util;
+
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+import today.seasoning.seasoning.common.exception.CustomException;
+
+import javax.annotation.PostConstruct;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+import java.util.Map;
+
+@Slf4j
+@Component
+public class SeasonalTermUtil {
+
+    @Value("${OPEN_API_KEY}")
+    private String API_KEY;
+
+    // 기록장이 열린 경우 : 해당하는 절기의 순번을 int로 반환 [1, 24]
+    // 기록장이 열리지 않은 경우 : -1 반환
+    @Getter
+    private static int currentTerm;
+
+    @Getter
+    private static int currentYear;
+
+    private final Map<String, Integer> solarTerms = Map.ofEntries(
+            Map.entry("입춘", 1),
+            Map.entry("우수", 2),
+            Map.entry("경칩", 3),
+            Map.entry("춘분", 4),
+            Map.entry("청명", 5),
+            Map.entry("곡우", 6),
+            Map.entry("입하", 7),
+            Map.entry("소만", 8),
+            Map.entry("망종", 9),
+            Map.entry("하지", 10),
+            Map.entry("소서", 11),
+            Map.entry("대서", 12),
+            Map.entry("입추", 13),
+            Map.entry("처서", 14),
+            Map.entry("백로", 15),
+            Map.entry("추분", 16),
+            Map.entry("한로", 17),
+            Map.entry("상강", 18),
+            Map.entry("입동", 19),
+            Map.entry("소설", 20),
+            Map.entry("대설", 21),
+            Map.entry("동지", 22),
+            Map.entry("소한", 23),
+            Map.entry("대한", 24));
+
+    @PostConstruct
+    private void initialize() {
+        currentTerm = findCurrentTerm();
+        System.out.println("currentTerm" + currentTerm);
+    }
+
+    @Scheduled(cron = "1 0 0 * * ?")
+    private void updateTerm() {
+        currentTerm = findCurrentTerm();
+    }
+
+    @Scheduled(cron = "1 0 0 1 1 ?")
+    private void updateYear() {
+        currentYear = LocalDate.now().getYear();
+    }
+
+    private int findCurrentTerm() {
+        LocalDate currentDate = LocalDate.now();
+        String year = String.valueOf(currentDate.getYear());
+        String month = String.format("%02d", currentDate.getMonthValue());
+
+        MonthTerms monthTerms = findMonthTerms(year, month);
+
+        long firstTermDiff = ChronoUnit.DAYS.between(monthTerms.firstDate, currentDate);
+        long secondTermDiff = ChronoUnit.DAYS.between(currentDate, monthTerms.secondDate);
+
+        if (Math.abs(firstTermDiff) < 3) {
+            return currentTerm = solarTerms.get(monthTerms.firstTerm);
+        }
+
+        if (Math.abs(secondTermDiff) < 3) {
+            return currentTerm = solarTerms.get(monthTerms.secondTerm);
+        }
+
+        return -1;
+    }
+
+    private MonthTerms findMonthTerms(String year, String month) {
+        try {
+            String xmlString = getXmlString(year, month);
+            return parseMonthTerms(xmlString);
+        } catch (Exception e) {
+            log.error(e.getMessage());
+            throw new CustomException(HttpStatus.INTERNAL_SERVER_ERROR, "절기 조회 실패");
+        }
+    }
+
+    private String getXmlString(String year, String month) throws Exception {
+        URL url = getUrl(year, month);
+
+        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+        conn.setRequestMethod("GET");
+        conn.setRequestProperty("Content-type", "application/json");
+
+        BufferedReader rd = (conn.getResponseCode() >= 200 && conn.getResponseCode() <= 300) ?
+                new BufferedReader(new InputStreamReader(conn.getInputStream())) :
+                new BufferedReader(new InputStreamReader(conn.getErrorStream()));
+
+        String line;
+        StringBuilder sb = new StringBuilder();
+        while ((line = rd.readLine()) != null) {
+            sb.append(line);
+        }
+        rd.close();
+        conn.disconnect();
+        return sb.toString();
+    }
+
+    private MonthTerms parseMonthTerms(String xmlString) throws Exception {
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        DocumentBuilder builder = factory.newDocumentBuilder();
+        ByteArrayInputStream input = new ByteArrayInputStream(xmlString.getBytes(StandardCharsets.UTF_8));
+        Document doc = builder.parse(input);
+        NodeList itemList = doc.getElementsByTagName("item");
+
+        Element firstTerm = (Element) itemList.item(0);
+        Element secondTerm = (Element) itemList.item(1);
+
+        return new MonthTerms(
+                firstTerm.getElementsByTagName("dateName").item(0).getTextContent(),
+                firstTerm.getElementsByTagName("locdate").item(0).getTextContent(),
+                secondTerm.getElementsByTagName("dateName").item(0).getTextContent(),
+                secondTerm.getElementsByTagName("locdate").item(0).getTextContent());
+    }
+
+    private URL getUrl(String year, String month) throws MalformedURLException {
+        StringBuilder urlBuilder = new StringBuilder();
+
+        // API 주소
+        urlBuilder.append("http://apis.data.go.kr/B090041/openapi/service/SpcdeInfoService/get24DivisionsInfo");
+
+        // API 키
+        urlBuilder.append("?" + URLEncoder.encode("serviceKey", StandardCharsets.UTF_8) + "=" + API_KEY); /*Service Key*/
+
+        // 조회 년도
+        urlBuilder.append("&" + URLEncoder.encode("solYear", StandardCharsets.UTF_8) + "=" + URLEncoder.encode(year, StandardCharsets.UTF_8));
+
+        // 조회 월
+        urlBuilder.append("&" + URLEncoder.encode("solMonth", StandardCharsets.UTF_8) + "=" + URLEncoder.encode(month, StandardCharsets.UTF_8));
+
+        // 고정
+        urlBuilder.append("&" + URLEncoder.encode("kst", StandardCharsets.UTF_8) + "=" + URLEncoder.encode("0000", StandardCharsets.UTF_8));
+        urlBuilder.append("&" + URLEncoder.encode("sunLongitude", StandardCharsets.UTF_8) + "=" + URLEncoder.encode("285", StandardCharsets.UTF_8));
+        urlBuilder.append("&" + URLEncoder.encode("numOfRows", StandardCharsets.UTF_8) + "=" + URLEncoder.encode("10", StandardCharsets.UTF_8));
+        urlBuilder.append("&" + URLEncoder.encode("pageNo", StandardCharsets.UTF_8) + "=" + URLEncoder.encode("1", StandardCharsets.UTF_8));
+        urlBuilder.append("&" + URLEncoder.encode("totalCount", StandardCharsets.UTF_8) + "=" + URLEncoder.encode("210114", StandardCharsets.UTF_8));
+
+        return new URL(urlBuilder.toString());
+    }
+
+
+    /*
+     * 조회한 달의 첫번째 절기와 두번째 절기 정보
+     * term : 절기 한글 이름
+     * date : 절기 날짜
+     *
+     * */
+    @Getter
+    private class MonthTerms {
+
+        private String firstTerm;
+        private String secondTerm;
+
+        private LocalDate firstDate;
+        private LocalDate secondDate;
+
+        public MonthTerms(String firstTerm, String firstDate, String secondTerm, String secondDate) {
+            this.firstTerm = firstTerm;
+            this.firstDate = LocalDate.parse(firstDate, DateTimeFormatter.ofPattern("yyyyMMdd"));
+
+            this.secondTerm = secondTerm;
+            this.secondDate = LocalDate.parse(secondDate, DateTimeFormatter.ofPattern("yyyyMMdd"));
+        }
+    }
+
+}

--- a/src/main/java/today/seasoning/seasoning/common/util/SolarTermUtil.java
+++ b/src/main/java/today/seasoning/seasoning/common/util/SolarTermUtil.java
@@ -1,5 +1,21 @@
 package today.seasoning.seasoning.common.util;
 
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+import java.util.Map;
+import javax.annotation.PostConstruct;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -10,22 +26,6 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
 import today.seasoning.seasoning.common.exception.CustomException;
-
-import javax.annotation.PostConstruct;
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import java.io.BufferedReader;
-import java.io.ByteArrayInputStream;
-import java.io.InputStreamReader;
-import java.net.HttpURLConnection;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
-import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
-import java.time.temporal.ChronoUnit;
-import java.util.Map;
 
 @Slf4j
 @Component
@@ -70,15 +70,25 @@ public class SolarTermUtil {
 
     @PostConstruct
     private void initialize() {
-        currentTerm = findCurrentTerm();
+        // 개발 기간에는 테스트 용으로 기록장 상시 오픈
+        currentTerm = (LocalDateTime.now().getSecond() % 24) + 1;
+
+		// 실제 절기 값
+		// currentTerm = findCurrentTerm();
+
         currentYear = LocalDate.now().getYear();
         log.info("절기 초기화 : " + currentTerm + " / 연도 초기화 : " + currentYear);
     }
 
     @Scheduled(cron = "1 0 0 * * ?")
     private void updateTerm() {
-        currentTerm = findCurrentTerm();
-        log.info("절기 갱신 : " + currentTerm);
+        // 개발 기간에는 테스트 용으로 기록장 상시 오픈
+        currentTerm = (LocalDateTime.now().getSecond() % 24) + 1;
+
+		// 실제 절기 값
+		// currentTerm = findCurrentTerm();
+
+		log.info("절기 갱신 : " + currentTerm);
     }
 
     @Scheduled(cron = "1 0 0 1 1 ?")

--- a/src/main/java/today/seasoning/seasoning/common/util/SolarTermUtil.java
+++ b/src/main/java/today/seasoning/seasoning/common/util/SolarTermUtil.java
@@ -71,17 +71,20 @@ public class SolarTermUtil {
     @PostConstruct
     private void initialize() {
         currentTerm = findCurrentTerm();
-        System.out.println("currentTerm" + currentTerm);
+        currentYear = LocalDate.now().getYear();
+        log.info("절기 초기화 : " + currentTerm + " / 연도 초기화 : " + currentYear);
     }
 
     @Scheduled(cron = "1 0 0 * * ?")
     private void updateTerm() {
         currentTerm = findCurrentTerm();
+        log.info("절기 갱신 : " + currentTerm);
     }
 
     @Scheduled(cron = "1 0 0 1 1 ?")
     private void updateYear() {
         currentYear = LocalDate.now().getYear();
+        log.info("연도 갱신 : " + currentYear);
     }
 
     private int findCurrentTerm() {

--- a/src/main/java/today/seasoning/seasoning/common/util/SolarTermUtil.java
+++ b/src/main/java/today/seasoning/seasoning/common/util/SolarTermUtil.java
@@ -29,7 +29,7 @@ import java.util.Map;
 
 @Slf4j
 @Component
-public class SeasonalTermUtil {
+public class SolarTermUtil {
 
     @Value("${OPEN_API_KEY}")
     private String API_KEY;

--- a/src/main/java/today/seasoning/seasoning/common/util/SolarTermUtil.java
+++ b/src/main/java/today/seasoning/seasoning/common/util/SolarTermUtil.java
@@ -70,21 +70,22 @@ public class SolarTermUtil {
 
     @PostConstruct
     private void initialize() {
-		currentTerm = findCurrentTerm(); // 실제 절기 값
+        currentTerm = findCurrentTerm(); // 실제 절기 값
         currentYear = LocalDate.now().getYear();
         log.info("절기 초기화 : " + currentTerm + " / 연도 초기화 : " + currentYear);
 
-		// 개발 기간에는 테스트 용으로 기록장 상시 오픈
-		currentTerm = (LocalDateTime.now().getSecond() % 24) + 1;
+        // 개발 기간에는 테스트 용으로 기록장 상시 오픈
+        currentTerm = (LocalDateTime.now().getNano() % 24) + 1;
     }
 
-    @Scheduled(cron = "1 0 0 * * ?")
+    @Scheduled(cron = "0 * * * * ?")
     private void updateTerm() {
-		currentTerm = findCurrentTerm(); // 실제 절기 값
-		log.info("절기 갱신 : " + currentTerm);
+        currentTerm = findCurrentTerm(); // 실제 절기 값
 
+
+        currentTerm = (LocalDateTime.now().getNano() % 24) + 1;
+		log.info("절기 갱신 : " + currentTerm);
 		// 개발 기간에는 테스트 용으로 기록장 상시 오픈
-		currentTerm = (LocalDateTime.now().getSecond() % 24) + 1;
     }
 
     @Scheduled(cron = "1 0 0 1 1 ?")

--- a/src/main/java/today/seasoning/seasoning/common/util/SolarTermUtil.java
+++ b/src/main/java/today/seasoning/seasoning/common/util/SolarTermUtil.java
@@ -9,7 +9,6 @@ import java.net.URL;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.Map;
@@ -31,186 +30,196 @@ import today.seasoning.seasoning.common.exception.CustomException;
 @Component
 public class SolarTermUtil {
 
-    @Value("${OPEN_API_KEY}")
-    private String API_KEY;
-
-    // 기록장이 열린 경우 : 해당하는 절기의 순번을 int로 반환 [1, 24]
-    // 기록장이 열리지 않은 경우 : -1 반환
-    @Getter
-    private static int currentTerm;
-
-    @Getter
-    private static int currentYear;
-
-    private final Map<String, Integer> solarTerms = Map.ofEntries(
-            Map.entry("입춘", 1),
-            Map.entry("우수", 2),
-            Map.entry("경칩", 3),
-            Map.entry("춘분", 4),
-            Map.entry("청명", 5),
-            Map.entry("곡우", 6),
-            Map.entry("입하", 7),
-            Map.entry("소만", 8),
-            Map.entry("망종", 9),
-            Map.entry("하지", 10),
-            Map.entry("소서", 11),
-            Map.entry("대서", 12),
-            Map.entry("입추", 13),
-            Map.entry("처서", 14),
-            Map.entry("백로", 15),
-            Map.entry("추분", 16),
-            Map.entry("한로", 17),
-            Map.entry("상강", 18),
-            Map.entry("입동", 19),
-            Map.entry("소설", 20),
-            Map.entry("대설", 21),
-            Map.entry("동지", 22),
-            Map.entry("소한", 23),
-            Map.entry("대한", 24));
-
-    @PostConstruct
-    private void initialize() {
-        currentTerm = findCurrentTerm(); // 실제 절기 값
-        currentYear = LocalDate.now().getYear();
-        log.info("절기 초기화 : " + currentTerm + " / 연도 초기화 : " + currentYear);
-
-        // 개발 기간에는 테스트 용으로 기록장 상시 오픈
-        currentTerm = (LocalDateTime.now().getNano() % 24) + 1;
-    }
-
-    @Scheduled(cron = "0 * * * * ?")
-    private void updateTerm() {
-        currentTerm = findCurrentTerm(); // 실제 절기 값
+	@Value("${OPEN_API_KEY}")
+	private String API_KEY;
 
 
-        currentTerm = (LocalDateTime.now().getNano() % 24) + 1;
+	@Getter
+	private static int currentYear;
+
+	/*
+	* 기록장이 열린 경우 : 열린 절기장에 해당하는 절기의 순번 [1, 24]
+	* 기록장이 열리지 않은 경우 : -1 반환
+	* */
+	@Getter
+	private static int currentTerm;
+
+	private final Map<String, Integer> solarTerms = Map.ofEntries(
+		Map.entry("입춘", 1),
+		Map.entry("우수", 2),
+		Map.entry("경칩", 3),
+		Map.entry("춘분", 4),
+		Map.entry("청명", 5),
+		Map.entry("곡우", 6),
+		Map.entry("입하", 7),
+		Map.entry("소만", 8),
+		Map.entry("망종", 9),
+		Map.entry("하지", 10),
+		Map.entry("소서", 11),
+		Map.entry("대서", 12),
+		Map.entry("입추", 13),
+		Map.entry("처서", 14),
+		Map.entry("백로", 15),
+		Map.entry("추분", 16),
+		Map.entry("한로", 17),
+		Map.entry("상강", 18),
+		Map.entry("입동", 19),
+		Map.entry("소설", 20),
+		Map.entry("대설", 21),
+		Map.entry("동지", 22),
+		Map.entry("소한", 23),
+		Map.entry("대한", 24));
+
+	@PostConstruct
+	private void initialize() {
+		currentTerm = findCurrentTerm(); // 실제 절기 순번
+		currentYear = LocalDate.now().getYear();
+		log.info("절기 초기화 : " + currentTerm + " / 연도 초기화 : " + currentYear);
+
+		// 해커톤 기간 동안, 춘분으로 고정
+		currentTerm = 4;
+	}
+
+	/* 매일 자정에 절기 갱신 */
+	@Scheduled(cron = "1 0 0 * * ?")
+	private void updateTerm() {
+		currentTerm = findCurrentTerm(); // 실제 절기 순번
 		log.info("절기 갱신 : " + currentTerm);
-		// 개발 기간에는 테스트 용으로 기록장 상시 오픈
-    }
 
-    @Scheduled(cron = "1 0 0 1 1 ?")
-    private void updateYear() {
-        currentYear = LocalDate.now().getYear();
-        log.info("연도 갱신 : " + currentYear);
-    }
+		// 해커톤 기간 동안, 춘분으로 고정
+		currentTerm = 4;
+	}
 
-    private int findCurrentTerm() {
-        LocalDate currentDate = LocalDate.now();
-        String year = String.valueOf(currentDate.getYear());
-        String month = String.format("%02d", currentDate.getMonthValue());
+	/* 매년 1월 1일에 연도 갱신 */
+	@Scheduled(cron = "1 0 0 1 1 ?")
+	private void updateYear() {
+		currentYear = LocalDate.now().getYear();
+		log.info("연도 갱신 : " + currentYear);
+	}
 
-        MonthTerms monthTerms = findMonthTerms(year, month);
+	private int findCurrentTerm() {
+		LocalDate currentDate = LocalDate.now();
+		String year = String.valueOf(currentDate.getYear());
+		String month = String.format("%02d", currentDate.getMonthValue());
 
-        long firstTermDiff = ChronoUnit.DAYS.between(monthTerms.firstDate, currentDate);
-        long secondTermDiff = ChronoUnit.DAYS.between(currentDate, monthTerms.secondDate);
+		MonthTerms monthTerms = findMonthTerms(year, month);
 
-        if (Math.abs(firstTermDiff) < 3) {
-            return currentTerm = solarTerms.get(monthTerms.firstTerm);
-        }
+		long firstTermDiff = ChronoUnit.DAYS.between(monthTerms.firstDate, currentDate);
+		long secondTermDiff = ChronoUnit.DAYS.between(currentDate, monthTerms.secondDate);
 
-        if (Math.abs(secondTermDiff) < 3) {
-            return currentTerm = solarTerms.get(monthTerms.secondTerm);
-        }
+		if (Math.abs(firstTermDiff) < 3) {
+			return solarTerms.get(monthTerms.firstTerm);
+		}
 
-        return -1;
-    }
+		if (Math.abs(secondTermDiff) < 3) {
+			return solarTerms.get(monthTerms.secondTerm);
+		}
 
-    private MonthTerms findMonthTerms(String year, String month) {
-        try {
-            String xmlString = getXmlString(year, month);
-            return parseMonthTerms(xmlString);
-        } catch (Exception e) {
-            log.error(e.getMessage());
-            throw new CustomException(HttpStatus.INTERNAL_SERVER_ERROR, "절기 조회 실패");
-        }
-    }
+		return -1;
+	}
 
-    private String getXmlString(String year, String month) throws Exception {
-        URL url = getUrl(year, month);
+	private MonthTerms findMonthTerms(String year, String month) {
+		try {
+			String xmlString = getXmlString(year, month);
+			return parseMonthTerms(xmlString);
+		} catch (Exception e) {
+			log.error(e.getMessage());
+			throw new CustomException(HttpStatus.INTERNAL_SERVER_ERROR, "절기 조회 실패");
+		}
+	}
 
-        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
-        conn.setRequestMethod("GET");
-        conn.setRequestProperty("Content-type", "application/json");
+	private String getXmlString(String year, String month) throws Exception {
+		URL url = getUrl(year, month);
 
-        BufferedReader rd = (conn.getResponseCode() >= 200 && conn.getResponseCode() <= 300) ?
-                new BufferedReader(new InputStreamReader(conn.getInputStream())) :
-                new BufferedReader(new InputStreamReader(conn.getErrorStream()));
+		HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+		conn.setRequestMethod("GET");
+		conn.setRequestProperty("Content-type", "application/json");
 
-        String line;
-        StringBuilder sb = new StringBuilder();
-        while ((line = rd.readLine()) != null) {
-            sb.append(line);
-        }
-        rd.close();
-        conn.disconnect();
-        return sb.toString();
-    }
+		BufferedReader rd = (conn.getResponseCode() >= 200 && conn.getResponseCode() <= 300) ?
+			new BufferedReader(new InputStreamReader(conn.getInputStream())) :
+			new BufferedReader(new InputStreamReader(conn.getErrorStream()));
 
-    private MonthTerms parseMonthTerms(String xmlString) throws Exception {
-        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
-        DocumentBuilder builder = factory.newDocumentBuilder();
-        ByteArrayInputStream input = new ByteArrayInputStream(xmlString.getBytes(StandardCharsets.UTF_8));
-        Document doc = builder.parse(input);
-        NodeList itemList = doc.getElementsByTagName("item");
+		String line;
+		StringBuilder sb = new StringBuilder();
+		while ((line = rd.readLine()) != null) {
+			sb.append(line);
+		}
+		rd.close();
+		conn.disconnect();
+		return sb.toString();
+	}
 
-        Element firstTerm = (Element) itemList.item(0);
-        Element secondTerm = (Element) itemList.item(1);
+	private MonthTerms parseMonthTerms(String xmlString) throws Exception {
+		DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+		DocumentBuilder builder = factory.newDocumentBuilder();
+		ByteArrayInputStream input = new ByteArrayInputStream(
+			xmlString.getBytes(StandardCharsets.UTF_8));
+		Document doc = builder.parse(input);
+		NodeList itemList = doc.getElementsByTagName("item");
 
-        return new MonthTerms(
-                firstTerm.getElementsByTagName("dateName").item(0).getTextContent(),
-                firstTerm.getElementsByTagName("locdate").item(0).getTextContent(),
-                secondTerm.getElementsByTagName("dateName").item(0).getTextContent(),
-                secondTerm.getElementsByTagName("locdate").item(0).getTextContent());
-    }
+		Element firstTerm = (Element) itemList.item(0);
+		Element secondTerm = (Element) itemList.item(1);
 
-    private URL getUrl(String year, String month) throws MalformedURLException {
-        StringBuilder urlBuilder = new StringBuilder();
+		return new MonthTerms(
+			firstTerm.getElementsByTagName("dateName").item(0).getTextContent(),
+			firstTerm.getElementsByTagName("locdate").item(0).getTextContent(),
+			secondTerm.getElementsByTagName("dateName").item(0).getTextContent(),
+			secondTerm.getElementsByTagName("locdate").item(0).getTextContent());
+	}
 
-        // API 주소
-        urlBuilder.append("http://apis.data.go.kr/B090041/openapi/service/SpcdeInfoService/get24DivisionsInfo");
+	private URL getUrl(String year, String month) throws MalformedURLException {
+		StringBuilder urlBuilder = new StringBuilder();
 
-        // API 키
-        urlBuilder.append("?" + URLEncoder.encode("serviceKey", StandardCharsets.UTF_8) + "=" + API_KEY); /*Service Key*/
+		// API 주소
+		urlBuilder.append(
+			"http://apis.data.go.kr/B090041/openapi/service/SpcdeInfoService/get24DivisionsInfo");
 
-        // 조회 년도
-        urlBuilder.append("&" + URLEncoder.encode("solYear", StandardCharsets.UTF_8) + "=" + URLEncoder.encode(year, StandardCharsets.UTF_8));
+		// API 키
+		urlBuilder.append("?" + URLEncoder.encode("serviceKey", StandardCharsets.UTF_8) + "="
+			+ API_KEY);
 
-        // 조회 월
-        urlBuilder.append("&" + URLEncoder.encode("solMonth", StandardCharsets.UTF_8) + "=" + URLEncoder.encode(month, StandardCharsets.UTF_8));
+		// 조회 년도
+		urlBuilder.append(
+			"&" + URLEncoder.encode("solYear", StandardCharsets.UTF_8) + "=" + URLEncoder.encode(
+				year, StandardCharsets.UTF_8));
 
-        // 고정
-        urlBuilder.append("&" + URLEncoder.encode("kst", StandardCharsets.UTF_8) + "=" + URLEncoder.encode("0000", StandardCharsets.UTF_8));
-        urlBuilder.append("&" + URLEncoder.encode("sunLongitude", StandardCharsets.UTF_8) + "=" + URLEncoder.encode("285", StandardCharsets.UTF_8));
-        urlBuilder.append("&" + URLEncoder.encode("numOfRows", StandardCharsets.UTF_8) + "=" + URLEncoder.encode("10", StandardCharsets.UTF_8));
-        urlBuilder.append("&" + URLEncoder.encode("pageNo", StandardCharsets.UTF_8) + "=" + URLEncoder.encode("1", StandardCharsets.UTF_8));
-        urlBuilder.append("&" + URLEncoder.encode("totalCount", StandardCharsets.UTF_8) + "=" + URLEncoder.encode("210114", StandardCharsets.UTF_8));
+		// 조회 월
+		urlBuilder.append(
+			"&" + URLEncoder.encode("solMonth", StandardCharsets.UTF_8) + "=" + URLEncoder.encode(
+				month, StandardCharsets.UTF_8));
 
-        return new URL(urlBuilder.toString());
-    }
+		// 고정값
+		urlBuilder.append("&" + URLEncoder.encode("kst", StandardCharsets.UTF_8) + "=" + URLEncoder.encode("0000", StandardCharsets.UTF_8));
+		urlBuilder.append("&" + URLEncoder.encode("sunLongitude", StandardCharsets.UTF_8) + "=" + URLEncoder.encode("285", StandardCharsets.UTF_8));
+		urlBuilder.append("&" + URLEncoder.encode("numOfRows", StandardCharsets.UTF_8) + "=" + URLEncoder.encode("10", StandardCharsets.UTF_8));
+		urlBuilder.append("&" + URLEncoder.encode("pageNo", StandardCharsets.UTF_8) + "=" + URLEncoder.encode("1", StandardCharsets.UTF_8));
+		urlBuilder.append("&" + URLEncoder.encode("totalCount", StandardCharsets.UTF_8) + "=" + URLEncoder.encode("210114", StandardCharsets.UTF_8));
 
+		return new URL(urlBuilder.toString());
+	}
 
-    /*
-     * 조회한 달의 첫번째 절기와 두번째 절기 정보
-     * term : 절기 한글 이름
-     * date : 절기 날짜
-     *
-     * */
-    @Getter
-    private class MonthTerms {
+	/*
+	 * 조회한 달의 첫번째 절기와 두번째 절기 정보
+	 * term : 절기 한글 이름
+	 * date : 절기 날짜
+	 * */
+	@Getter
+	private class MonthTerms {
 
-        private String firstTerm;
-        private String secondTerm;
+		private String firstTerm;
+		private String secondTerm;
 
-        private LocalDate firstDate;
-        private LocalDate secondDate;
+		private LocalDate firstDate;
+		private LocalDate secondDate;
 
-        public MonthTerms(String firstTerm, String firstDate, String secondTerm, String secondDate) {
-            this.firstTerm = firstTerm;
-            this.firstDate = LocalDate.parse(firstDate, DateTimeFormatter.ofPattern("yyyyMMdd"));
+		public MonthTerms(String firstTerm, String firstDate, String secondTerm,
+			String secondDate) {
+			this.firstTerm = firstTerm;
+			this.firstDate = LocalDate.parse(firstDate, DateTimeFormatter.ofPattern("yyyyMMdd"));
 
-            this.secondTerm = secondTerm;
-            this.secondDate = LocalDate.parse(secondDate, DateTimeFormatter.ofPattern("yyyyMMdd"));
-        }
-    }
+			this.secondTerm = secondTerm;
+			this.secondDate = LocalDate.parse(secondDate, DateTimeFormatter.ofPattern("yyyyMMdd"));
+		}
+	}
 
 }

--- a/src/main/java/today/seasoning/seasoning/common/util/SolarTermUtil.java
+++ b/src/main/java/today/seasoning/seasoning/common/util/SolarTermUtil.java
@@ -70,25 +70,21 @@ public class SolarTermUtil {
 
     @PostConstruct
     private void initialize() {
-        // 개발 기간에는 테스트 용으로 기록장 상시 오픈
-        currentTerm = (LocalDateTime.now().getSecond() % 24) + 1;
-
-		// 실제 절기 값
-		// currentTerm = findCurrentTerm();
-
+		currentTerm = findCurrentTerm(); // 실제 절기 값
         currentYear = LocalDate.now().getYear();
         log.info("절기 초기화 : " + currentTerm + " / 연도 초기화 : " + currentYear);
+
+		// 개발 기간에는 테스트 용으로 기록장 상시 오픈
+		currentTerm = (LocalDateTime.now().getSecond() % 24) + 1;
     }
 
     @Scheduled(cron = "1 0 0 * * ?")
     private void updateTerm() {
-        // 개발 기간에는 테스트 용으로 기록장 상시 오픈
-        currentTerm = (LocalDateTime.now().getSecond() % 24) + 1;
-
-		// 실제 절기 값
-		// currentTerm = findCurrentTerm();
-
+		currentTerm = findCurrentTerm(); // 실제 절기 값
 		log.info("절기 갱신 : " + currentTerm);
+
+		// 개발 기간에는 테스트 용으로 기록장 상시 오픈
+		currentTerm = (LocalDateTime.now().getSecond() % 24) + 1;
     }
 
     @Scheduled(cron = "1 0 0 1 1 ?")

--- a/src/main/java/today/seasoning/seasoning/common/util/TsidUtil.java
+++ b/src/main/java/today/seasoning/seasoning/common/util/TsidUtil.java
@@ -1,0 +1,20 @@
+package today.seasoning.seasoning.common.util;
+
+import com.github.f4b6a3.tsid.Tsid;
+import com.github.f4b6a3.tsid.TsidCreator;
+
+public class TsidUtil {
+
+	public static Long createLong() {
+		return TsidCreator.getTsid().toLong();
+	}
+
+	public static String toString(Long id) {
+		return Tsid.from(id).encode(62);
+	}
+
+	public static Long toLong(String id) {
+		return Tsid.decode(id, 62).toLong();
+	}
+
+}


### PR DESCRIPTION
## 📟 연결된 이슈
close #25

## 👷 작업한 내용
- 절기 계산 유틸리티 클래스 구현
  - 현재 열린 기록장에 해당하는 절기의 순번을 반환하는 메서드 작성
  - 현재 년도를 반환하는 편의 메서드 작성
  - 매일 자정에 절기 정보가 갱신되도록 스케줄링 구현
  - 매년 연도 정보가 갱신되도록 스케줄링 구현
- 기록장 등록 기능 구현
- 해커톤 기간에는 절기가 찾아오지 않기 때문에 임시로 춘분으로 고정
- 웹 DTO 유효성 검증 로직 구현 
  - @Valid 어노테이션 적용

## 🚨 참고 사항
절기 정보는 공공데이터 포털의 '한국천문연구원_특일 정보' API 이용
(주소 : https://www.data.go.kr/tcs/dss/selectApiDataDetailView.do?publicDataPk=15012690)

## 📸 스크린샷
<img width="1624" alt="Untitled" src="https://github.com/goormthon-Univ/TEAM_1/assets/107951175/7eb4d281-8e02-4f5e-8c44-d03a22653e82">

- 유효하지 않은 값이 전달되면 Bad Request 응답
