### PR TITLE
기록장 연도별 조회, 절기별 조회 기능 구현

### DIFF
--- a/src/main/java/today/seasoning/seasoning/article/controller/ArticleController.java
+++ b/src/main/java/today/seasoning/seasoning/article/controller/ArticleController.java
@@ -22,6 +22,8 @@ import today.seasoning.seasoning.article.dto.UpdateArticleCommand;
 import today.seasoning.seasoning.article.dto.UpdateArticleDto;
 import today.seasoning.seasoning.article.service.DeleteArticleService;
 import today.seasoning.seasoning.article.service.FindArticleService;
+import today.seasoning.seasoning.article.service.FindMyArticlesByTermResult;
+import today.seasoning.seasoning.article.service.FindMyArticlesByTermService;
 import today.seasoning.seasoning.article.service.FindMyArticlesByYearService;
 import today.seasoning.seasoning.article.service.RegisterArticleService;
 import today.seasoning.seasoning.article.service.UpdateArticleService;
@@ -38,6 +40,7 @@ public class ArticleController {
 	private final UpdateArticleService updateArticleService;
 	private final DeleteArticleService deleteArticleService;
 	private final FindMyArticlesByYearService findMyArticlesByYearService;
+	private final FindMyArticlesByTermService findMyArticlesByTermService;
 
 	@PostMapping
 	public ResponseEntity<String> registerArticle(@AuthenticationPrincipal UserPrincipal principal,
@@ -106,6 +109,18 @@ public class ArticleController {
 		Long userId = principal.getId();
 
 		List<FindMyArticlesByYearResult> result = findMyArticlesByYearService.doFind(userId, year);
+
+		return ResponseEntity.ok(result);
+	}
+
+	@GetMapping("/list/term/{term}")
+	public ResponseEntity<List<FindMyArticlesByTermResult>> findMyArticlesByTerm(
+		@AuthenticationPrincipal UserPrincipal principal,
+		@PathVariable Integer term) {
+
+		Long userId = principal.getId();
+
+		List<FindMyArticlesByTermResult> result = findMyArticlesByTermService.doFind(userId, term);
 
 		return ResponseEntity.ok(result);
 	}

--- a/src/main/java/today/seasoning/seasoning/article/controller/ArticleController.java
+++ b/src/main/java/today/seasoning/seasoning/article/controller/ArticleController.java
@@ -15,12 +15,14 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 import today.seasoning.seasoning.article.dto.FindArticleResult;
+import today.seasoning.seasoning.article.dto.FindMyArticlesByYearResult;
 import today.seasoning.seasoning.article.dto.RegisterArticleCommand;
 import today.seasoning.seasoning.article.dto.RegisterArticleDto;
 import today.seasoning.seasoning.article.dto.UpdateArticleCommand;
 import today.seasoning.seasoning.article.dto.UpdateArticleDto;
 import today.seasoning.seasoning.article.service.DeleteArticleService;
 import today.seasoning.seasoning.article.service.FindArticleService;
+import today.seasoning.seasoning.article.service.FindMyArticlesByYearService;
 import today.seasoning.seasoning.article.service.RegisterArticleService;
 import today.seasoning.seasoning.article.service.UpdateArticleService;
 import today.seasoning.seasoning.common.UserPrincipal;
@@ -35,6 +37,7 @@ public class ArticleController {
 	private final FindArticleService findArticleService;
 	private final UpdateArticleService updateArticleService;
 	private final DeleteArticleService deleteArticleService;
+	private final FindMyArticlesByYearService findMyArticlesByYearService;
 
 	@PostMapping
 	public ResponseEntity<String> registerArticle(@AuthenticationPrincipal UserPrincipal principal,
@@ -93,5 +96,17 @@ public class ArticleController {
 		deleteArticleService.doDelete(userId, articleId);
 
 		return ResponseEntity.ok().build();
+	}
+
+	@GetMapping("/list/year/{year}")
+	public ResponseEntity<List<FindMyArticlesByYearResult>> findMyArticlesByYear(
+		@AuthenticationPrincipal UserPrincipal principal,
+		@PathVariable Integer year) {
+
+		Long userId = principal.getId();
+
+		List<FindMyArticlesByYearResult> result = findMyArticlesByYearService.doFind(userId, year);
+
+		return ResponseEntity.ok(result);
 	}
 }

--- a/src/main/java/today/seasoning/seasoning/article/domain/ArticleRepository.java
+++ b/src/main/java/today/seasoning/seasoning/article/domain/ArticleRepository.java
@@ -9,4 +9,7 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
 
 	@Query("SELECT a From Article a WHERE a.user.id = :userId AND a.createdYear = :year")
 	List<Article> findByUserIdAndYear(@Param("userId") Long userId, @Param("year") int year);
+
+	@Query("SELECT a From Article a WHERE a.user.id = :userId AND a.createdTerm = :term")
+	List<Article> findByUserIdAndTerm(@Param("userId") Long userId, @Param("term") int term);
 }

--- a/src/main/java/today/seasoning/seasoning/article/domain/ArticleRepository.java
+++ b/src/main/java/today/seasoning/seasoning/article/domain/ArticleRepository.java
@@ -1,7 +1,12 @@
 package today.seasoning.seasoning.article.domain;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ArticleRepository extends JpaRepository<Article, Long> {
 
+	@Query("SELECT a From Article a WHERE a.user.id = :userId AND a.createdYear = :year")
+	List<Article> findByUserIdAndYear(@Param("userId") Long userId, @Param("year") int year);
 }

--- a/src/main/java/today/seasoning/seasoning/article/dto/FindMyArticlesByYearResult.java
+++ b/src/main/java/today/seasoning/seasoning/article/dto/FindMyArticlesByYearResult.java
@@ -1,0 +1,15 @@
+package today.seasoning.seasoning.article.dto;
+
+import lombok.Getter;
+
+@Getter
+public class FindMyArticlesByYearResult {
+
+	private final String id;
+	private final int term;
+
+	public FindMyArticlesByYearResult(String id, int term) {
+		this.id = id;
+		this.term = term;
+	}
+}

--- a/src/main/java/today/seasoning/seasoning/article/service/FindMyArticlesByTermResult.java
+++ b/src/main/java/today/seasoning/seasoning/article/service/FindMyArticlesByTermResult.java
@@ -1,0 +1,19 @@
+package today.seasoning.seasoning.article.service;
+
+import lombok.Getter;
+
+@Getter
+public class FindMyArticlesByTermResult {
+
+	private final String id;
+	private final int year;
+	private final String preview;
+	private final String image;
+
+	public FindMyArticlesByTermResult(String id, int year, String preview, String image) {
+		this.id = id;
+		this.year = year;
+		this.preview = preview;
+		this.image = image;
+	}
+}

--- a/src/main/java/today/seasoning/seasoning/article/service/FindMyArticlesByTermService.java
+++ b/src/main/java/today/seasoning/seasoning/article/service/FindMyArticlesByTermService.java
@@ -1,0 +1,52 @@
+package today.seasoning.seasoning.article.service;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import today.seasoning.seasoning.article.domain.Article;
+import today.seasoning.seasoning.article.domain.ArticleImage;
+import today.seasoning.seasoning.article.domain.ArticleRepository;
+import today.seasoning.seasoning.common.util.TsidUtil;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FindMyArticlesByTermService {
+
+	private final ArticleRepository articleRepository;
+
+	public List<FindMyArticlesByTermResult> doFind(Long userId, int term) {
+		return articleRepository.findByUserIdAndTerm(userId, term)
+			.stream()
+			.map(this::toDto)
+			.collect(Collectors.toList());
+	}
+
+	private FindMyArticlesByTermResult toDto(Article article) {
+		String contentsPreview = getContentsPreview(article.getContents());
+
+		String thumbnailImageUrl = getFirstImageUrl(article.getArticleImages());
+
+		return new FindMyArticlesByTermResult(
+			TsidUtil.toString(article.getId()),
+			article.getCreatedYear(),
+			contentsPreview,
+			thumbnailImageUrl);
+	}
+
+	private String getFirstImageUrl(List<ArticleImage> images) {
+		return images
+			.stream()
+			.min(Comparator.comparingInt(ArticleImage::getSequence))
+			.map(ArticleImage::getUrl)
+			.orElse(null);
+	}
+
+	private String getContentsPreview(String contents) {
+		int previewLength = Math.min(contents.length(), 150);
+		return contents.substring(0, previewLength);
+	}
+}

--- a/src/main/java/today/seasoning/seasoning/article/service/FindMyArticlesByYearService.java
+++ b/src/main/java/today/seasoning/seasoning/article/service/FindMyArticlesByYearService.java
@@ -1,0 +1,32 @@
+package today.seasoning.seasoning.article.service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import today.seasoning.seasoning.article.domain.Article;
+import today.seasoning.seasoning.article.domain.ArticleRepository;
+import today.seasoning.seasoning.article.dto.FindMyArticlesByYearResult;
+import today.seasoning.seasoning.common.util.TsidUtil;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FindMyArticlesByYearService {
+
+	private final ArticleRepository articleRepository;
+
+	public List<FindMyArticlesByYearResult> doFind(Long userId, int year) {
+		return articleRepository.findByUserIdAndYear(userId, year)
+			.stream()
+			.map(this::toDto)
+			.collect(Collectors.toList());
+	}
+
+	private FindMyArticlesByYearResult toDto(Article article) {
+		return new FindMyArticlesByYearResult(
+			TsidUtil.toString(article.getId()),
+			article.getCreatedTerm());
+	}
+}

--- a/src/main/java/today/seasoning/seasoning/common/enums/FriendshipStatus.java
+++ b/src/main/java/today/seasoning/seasoning/common/enums/FriendshipStatus.java
@@ -1,0 +1,6 @@
+package today.seasoning.seasoning.common.enums;
+
+public enum FriendshipStatus {
+    // 친구, 친구 신청을 보냄, 친구 신청을 받음, 친구 아님
+    FRIEND, SENT, RECEIVED, UNFRIEND, SELF
+}

--- a/src/main/java/today/seasoning/seasoning/friendship/controller/FriendshipController.java
+++ b/src/main/java/today/seasoning/seasoning/friendship/controller/FriendshipController.java
@@ -9,6 +9,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import today.seasoning.seasoning.common.UserPrincipal;
 import today.seasoning.seasoning.friendship.dto.FindUserFriendsResult;
+import today.seasoning.seasoning.friendship.dto.SearchFriendResult;
 import today.seasoning.seasoning.friendship.dto.ToUserAccountIdDto;
 import today.seasoning.seasoning.friendship.service.*;
 
@@ -23,6 +24,7 @@ public class FriendshipController {
     private final CancelFriendshipService cancelFriendshipService;
     private final DeclineFriendshipService declineFriendshipService;
     private final DeleteFriendshipService deleteFriendshipService;
+    private final SearchFriendshipService searchFriendshipService;
 
     @RequestMapping("/add")
     public ResponseEntity<String> requestFriendship(
@@ -62,7 +64,7 @@ public class FriendshipController {
     }
 
     @DeleteMapping("/add/cancel")
-    public ResponseEntity<String> cacelFriendship(
+    public ResponseEntity<String> cancelFriendship(
             @AuthenticationPrincipal UserPrincipal principal,
             @Valid @RequestBody ToUserAccountIdDto toUserAccountIdDto) {
 
@@ -98,5 +100,17 @@ public class FriendshipController {
         deleteFriendshipService.doService(userId, toUserAccountId);
 
         return ResponseEntity.ok().body("삭제 완료");
+    }
+
+    @GetMapping("/search")
+    public ResponseEntity<SearchFriendResult> searchFriend(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @RequestParam("keyword") String friendAccountId) {
+
+        Long userId = principal.getId();
+
+        SearchFriendResult result = searchFriendshipService.doService(userId, friendAccountId);
+
+        return ResponseEntity.ok().body(result);
     }
 }

--- a/src/main/java/today/seasoning/seasoning/friendship/dto/SearchFriendResult.java
+++ b/src/main/java/today/seasoning/seasoning/friendship/dto/SearchFriendResult.java
@@ -1,0 +1,25 @@
+package today.seasoning.seasoning.friendship.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import today.seasoning.seasoning.common.enums.FriendshipStatus;
+
+@Getter
+@RequiredArgsConstructor
+public class SearchFriendResult {
+    private final String nickname;
+    private final String image;
+    private final String accountId;
+    private FriendshipStatus friendshipStatus;
+
+    public SearchFriendResult(String nickname, String image, String accountId, FriendshipStatus friendshipStatus) {
+        this.nickname = nickname;
+        this.image = image;
+        this.accountId = accountId;
+        this.friendshipStatus = friendshipStatus;
+    }
+
+    public void setFriendshipStatus(FriendshipStatus friendshipStatus) {
+        this.friendshipStatus = friendshipStatus;
+    }
+}

--- a/src/main/java/today/seasoning/seasoning/friendship/service/SearchFriendshipService.java
+++ b/src/main/java/today/seasoning/seasoning/friendship/service/SearchFriendshipService.java
@@ -1,0 +1,59 @@
+package today.seasoning.seasoning.friendship.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import today.seasoning.seasoning.common.enums.FriendshipStatus;
+import today.seasoning.seasoning.common.exception.CustomException;
+import today.seasoning.seasoning.friendship.domain.Friendship;
+import today.seasoning.seasoning.friendship.domain.FriendshipRepository;
+import today.seasoning.seasoning.friendship.dto.SearchFriendResult;
+import today.seasoning.seasoning.user.domain.User;
+import today.seasoning.seasoning.user.domain.UserRepository;
+
+@Service
+@RequiredArgsConstructor
+public class SearchFriendshipService {
+
+    private final FriendshipRepository friendshipRepository;
+    private final UserRepository userRepository;
+
+    @Transactional(readOnly = true)
+    public SearchFriendResult doService(Long userId, String friendAccountId) {
+
+        User friend = userRepository.findByAccountId(friendAccountId).orElseThrow(
+                () -> new CustomException(HttpStatus.NOT_FOUND, "친구 검색 실패"));
+
+        SearchFriendResult searchFriendResult = new SearchFriendResult(friend.getNickname(),
+                friend.getProfileImageUrl(),
+                friendAccountId,
+                FriendshipStatus.UNFRIEND);
+
+        // 나 자신인 경우
+        if (userId.equals(friend.getId())) {
+            searchFriendResult.setFriendshipStatus(FriendshipStatus.SELF);
+            return searchFriendResult;
+        }
+
+        Friendship forwardFriendship = friendshipRepository.findByUserIds(userId, friend.getId()).orElse(null);
+        Friendship reverseFriendship = friendshipRepository.findByUserIds(friend.getId(), userId).orElse(null);
+
+        // 친구 관계가 있는 경우
+        if (forwardFriendship != null) {
+            if (forwardFriendship.isValid()) {
+                // 서로 친구인 상태
+                if (reverseFriendship.isValid()) {
+                    searchFriendResult.setFriendshipStatus(FriendshipStatus.FRIEND);
+                } else { // 로그인한 사용자가 친구 요청한 상태
+                    searchFriendResult.setFriendshipStatus(FriendshipStatus.SENT);
+                }
+            } else {
+                // 로그인한 사용자가 친구 요청 받은 상태
+                searchFriendResult.setFriendshipStatus(FriendshipStatus.RECEIVED);
+            }
+        }
+        return searchFriendResult;
+    }
+
+}


### PR DESCRIPTION
## 📟 연결된 이슈
- close #43
- close #44  

## 👷 작업한 내용
- 기록장 연도별 조회 기능 구현
  - term : 절기의 순번을 나타내는 1 이상 24 이하의 정수
- 기록잘 절기별 조회 기능 구현
  - image: 첫번째 사진의 주소, 없으면 null
  - preview: 본문의 첫 150글자
