### PR TITLE
콜라주 조회 기능 구현

### DIFF
--- a/src/main/java/today/seasoning/seasoning/article/controller/ArticleController.java
+++ b/src/main/java/today/seasoning/seasoning/article/controller/ArticleController.java
@@ -11,10 +11,12 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 import today.seasoning.seasoning.article.dto.FindArticleResult;
+import today.seasoning.seasoning.article.dto.FindCollageResult;
 import today.seasoning.seasoning.article.dto.FindMyArticlesByYearResult;
 import today.seasoning.seasoning.article.dto.RegisterArticleCommand;
 import today.seasoning.seasoning.article.dto.RegisterArticleDto;
@@ -23,6 +25,7 @@ import today.seasoning.seasoning.article.dto.UpdateArticleDto;
 import today.seasoning.seasoning.article.service.ArticleLikeService;
 import today.seasoning.seasoning.article.service.DeleteArticleService;
 import today.seasoning.seasoning.article.service.FindArticleService;
+import today.seasoning.seasoning.article.service.FindCollageService;
 import today.seasoning.seasoning.article.service.FindMyArticlesByTermResult;
 import today.seasoning.seasoning.article.service.FindMyArticlesByTermService;
 import today.seasoning.seasoning.article.service.FindMyArticlesByYearService;
@@ -43,6 +46,7 @@ public class ArticleController {
 	private final FindMyArticlesByYearService findMyArticlesByYearService;
 	private final FindMyArticlesByTermService findMyArticlesByTermService;
 	private final ArticleLikeService articleLikeService;
+	private final FindCollageService findCollageService;
 
 	@PostMapping
 	public ResponseEntity<String> registerArticle(@AuthenticationPrincipal UserPrincipal principal,
@@ -148,5 +152,15 @@ public class ArticleController {
 		articleLikeService.cancelLike(userId, articleId);
 
 		return ResponseEntity.ok().build();
+	}
+
+	@GetMapping("/collage")
+	public ResponseEntity<List<FindCollageResult>> findCollage(
+		@AuthenticationPrincipal UserPrincipal principal,
+		@RequestParam("year") Integer year) {
+
+		Long userId = principal.getId();
+		List<FindCollageResult> collage = findCollageService.doFind(userId, year);
+		return ResponseEntity.ok(collage);
 	}
 }

--- a/src/main/java/today/seasoning/seasoning/article/dto/FindCollageResult.java
+++ b/src/main/java/today/seasoning/seasoning/article/dto/FindCollageResult.java
@@ -5,13 +5,13 @@ import lombok.Getter;
 @Getter
 public class FindCollageResult {
 
+	private final int term;
 	private final String articleId;
 	private final String image;
-	private final int term;
 
-	public FindCollageResult(String articleId, String image, int term) {
+	public FindCollageResult(int term, String articleId, String image) {
+		this.term = term;
 		this.articleId = articleId;
 		this.image = image;
-		this.term = term;
 	}
 }

--- a/src/main/java/today/seasoning/seasoning/article/dto/FindCollageResult.java
+++ b/src/main/java/today/seasoning/seasoning/article/dto/FindCollageResult.java
@@ -1,0 +1,17 @@
+package today.seasoning.seasoning.article.dto;
+
+import lombok.Getter;
+
+@Getter
+public class FindCollageResult {
+
+	private final String articleId;
+	private final String image;
+	private final int term;
+
+	public FindCollageResult(String articleId, String image, int term) {
+		this.articleId = articleId;
+		this.image = image;
+		this.term = term;
+	}
+}

--- a/src/main/java/today/seasoning/seasoning/article/service/FindCollageService.java
+++ b/src/main/java/today/seasoning/seasoning/article/service/FindCollageService.java
@@ -42,9 +42,9 @@ public class FindCollageService {
 		String firstImageUrl = getFirstImageUrl(articleImages);
 
 		return new FindCollageResult(
+			article.getCreatedTerm(),
 			TsidUtil.toString(article.getId()),
-			firstImageUrl,
-			article.getCreatedTerm());
+			firstImageUrl);
 	}
 
 	private String getFirstImageUrl(List<ArticleImage> images) {

--- a/src/main/java/today/seasoning/seasoning/article/service/FindCollageService.java
+++ b/src/main/java/today/seasoning/seasoning/article/service/FindCollageService.java
@@ -1,0 +1,57 @@
+package today.seasoning.seasoning.article.service;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import today.seasoning.seasoning.article.domain.Article;
+import today.seasoning.seasoning.article.domain.ArticleImage;
+import today.seasoning.seasoning.article.domain.ArticleRepository;
+import today.seasoning.seasoning.article.dto.FindCollageResult;
+import today.seasoning.seasoning.common.exception.CustomException;
+import today.seasoning.seasoning.common.util.TsidUtil;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FindCollageService {
+
+	private final ArticleRepository articleRepository;
+
+	public List<FindCollageResult> doFind(Long userId, int year) {
+		validateYear(year);
+
+		return articleRepository.findByUserIdAndYear(userId, year)
+			.stream()
+			.map(this::toDto)
+			.collect(Collectors.toList());
+	}
+
+	private void validateYear(Integer year) {
+		if (year == null || year < 2023 || year > 2100) {
+			throw new CustomException(HttpStatus.BAD_REQUEST, "조회 년도 오류");
+		}
+	}
+
+	public FindCollageResult toDto(Article article) {
+		List<ArticleImage> articleImages = article.getArticleImages();
+
+		String firstImageUrl = getFirstImageUrl(articleImages);
+
+		return new FindCollageResult(
+			TsidUtil.toString(article.getId()),
+			firstImageUrl,
+			article.getCreatedTerm());
+	}
+
+	private String getFirstImageUrl(List<ArticleImage> images) {
+		return images
+			.stream()
+			.min(Comparator.comparingInt(ArticleImage::getSequence))
+			.map(ArticleImage::getUrl)
+			.orElse(null);
+	}
+}


### PR DESCRIPTION
## 📟 연결된 이슈
- close #50 

## 👷 작업한 내용
- 콜라주 조회 기능 구현

## 🚨 참고 사항
- 특정 년도에 등록된 절기장만 조회, 작성하지 않은 절기의 경우 응답에 포함시키지 않음 
- 기록장의 첫번째 사진의 이미지 주소를 응답
- 기록장에 사진이 없으면 image에 null 응답

## 📸 스크린샷
<img width="633" alt="image" src="https://github.com/goormthon-Univ/TEAM_1/assets/107951175/55fe90f5-c161-43dd-b148-770de141e595">