### PR TITLE
친구 기록장 목록 조회 기능 구현

### DIFF
--- a/src/main/java/today/seasoning/seasoning/article/controller/ArticleController.java
+++ b/src/main/java/today/seasoning/seasoning/article/controller/ArticleController.java
@@ -18,6 +18,7 @@ import org.springframework.web.multipart.MultipartFile;
 import today.seasoning.seasoning.article.dto.FindArticleResult;
 import today.seasoning.seasoning.article.dto.FindCollageResult;
 import today.seasoning.seasoning.article.dto.FindMyArticlesByYearResult;
+import today.seasoning.seasoning.article.dto.FindMyFriendsArticlesResult;
 import today.seasoning.seasoning.article.dto.RegisterArticleCommand;
 import today.seasoning.seasoning.article.dto.RegisterArticleDto;
 import today.seasoning.seasoning.article.dto.UpdateArticleCommand;
@@ -29,6 +30,7 @@ import today.seasoning.seasoning.article.service.FindCollageService;
 import today.seasoning.seasoning.article.service.FindMyArticlesByTermResult;
 import today.seasoning.seasoning.article.service.FindMyArticlesByTermService;
 import today.seasoning.seasoning.article.service.FindMyArticlesByYearService;
+import today.seasoning.seasoning.article.service.FindMyFriendsArticlesService;
 import today.seasoning.seasoning.article.service.RegisterArticleService;
 import today.seasoning.seasoning.article.service.UpdateArticleService;
 import today.seasoning.seasoning.common.UserPrincipal;
@@ -47,6 +49,7 @@ public class ArticleController {
 	private final FindMyArticlesByTermService findMyArticlesByTermService;
 	private final ArticleLikeService articleLikeService;
 	private final FindCollageService findCollageService;
+	private final FindMyFriendsArticlesService findMyFriendsArticlesService;
 
 	@PostMapping
 	public ResponseEntity<String> registerArticle(@AuthenticationPrincipal UserPrincipal principal,
@@ -162,5 +165,20 @@ public class ArticleController {
 		Long userId = principal.getId();
 		List<FindCollageResult> collage = findCollageService.doFind(userId, year);
 		return ResponseEntity.ok(collage);
+	}
+
+	@GetMapping("/friends")
+	public ResponseEntity<List<FindMyFriendsArticlesResult>> findMyFriendsArticles(
+		@AuthenticationPrincipal UserPrincipal principal,
+		@RequestParam(name = "lastId", defaultValue = "AzL8n0Y58m7") String stringArticleId,
+		@RequestParam(name = "size", defaultValue = "10") Integer pageSize) {
+
+		Long userId = principal.getId();
+		Long lastArticleId = TsidUtil.toLong(stringArticleId);
+
+		List<FindMyFriendsArticlesResult> findMyFriendsArticlesResults =
+			findMyFriendsArticlesService.doFind(userId, lastArticleId, pageSize);
+
+		return ResponseEntity.ok(findMyFriendsArticlesResults);
 	}
 }

--- a/src/main/java/today/seasoning/seasoning/article/dto/FindMyFriendsArticlesResult.java
+++ b/src/main/java/today/seasoning/seasoning/article/dto/FindMyFriendsArticlesResult.java
@@ -1,0 +1,16 @@
+package today.seasoning.seasoning.article.dto;
+
+import lombok.Getter;
+
+@Getter
+public class FindMyFriendsArticlesResult {
+
+	private final UserProfileDto profile;
+	private final FriendArticleDto article;
+
+	public FindMyFriendsArticlesResult(UserProfileDto profile,
+		FriendArticleDto article) {
+		this.profile = profile;
+		this.article = article;
+	}
+}

--- a/src/main/java/today/seasoning/seasoning/article/dto/FriendArticleDto.java
+++ b/src/main/java/today/seasoning/seasoning/article/dto/FriendArticleDto.java
@@ -1,0 +1,21 @@
+package today.seasoning.seasoning.article.dto;
+
+import lombok.Getter;
+
+@Getter
+public class FriendArticleDto {
+
+	private final String id;
+	private final int year;
+	private final int term;
+	private final String preview;
+	private final String image;
+
+	public FriendArticleDto(String id, int year, int term, String preview, String image) {
+		this.id = id;
+		this.year = year;
+		this.term = term;
+		this.preview = preview;
+		this.image = image;
+	}
+}

--- a/src/main/java/today/seasoning/seasoning/article/dto/UserProfileDto.java
+++ b/src/main/java/today/seasoning/seasoning/article/dto/UserProfileDto.java
@@ -1,0 +1,25 @@
+package today.seasoning.seasoning.article.dto;
+
+import lombok.Getter;
+import today.seasoning.seasoning.user.domain.User;
+
+@Getter
+public class UserProfileDto {
+
+	private final String nickname;
+	private final String accountID;
+	private final String image;
+
+	public UserProfileDto(String nickname, String accountID, String image) {
+		this.nickname = nickname;
+		this.accountID = accountID;
+		this.image = image;
+	}
+
+	public static UserProfileDto build(User user) {
+		return new UserProfileDto(
+			user.getNickname(),
+			user.getAccountId(),
+			user.getProfileImageUrl());
+	}
+}

--- a/src/main/java/today/seasoning/seasoning/article/service/FindMyFriendsArticlesService.java
+++ b/src/main/java/today/seasoning/seasoning/article/service/FindMyFriendsArticlesService.java
@@ -1,0 +1,82 @@
+package today.seasoning.seasoning.article.service;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import today.seasoning.seasoning.article.domain.Article;
+import today.seasoning.seasoning.article.domain.ArticleImage;
+import today.seasoning.seasoning.article.dto.FindMyFriendsArticlesResult;
+import today.seasoning.seasoning.article.dto.FriendArticleDto;
+import today.seasoning.seasoning.article.dto.UserProfileDto;
+import today.seasoning.seasoning.common.util.TsidUtil;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FindMyFriendsArticlesService {
+
+	private final EntityManager entityManager;
+
+	private final String SQL = "SELECT a FROM Article a " +
+		"INNER JOIN Friendship f ON a.user.id = f.toUser.id " +
+		"WHERE f.fromUser.id = :userId " +
+		"AND f.valid = true " +
+		"AND EXISTS (" +
+		"   SELECT 1 FROM Friendship f2 " +
+		"   WHERE f2.fromUser.id = a.user.id " +
+		"   AND f2.toUser.id = :userId " +
+		"   AND f2.valid = true" +
+		") " +
+		"AND a.published = true " +
+		"AND a.id < :articleId " +
+		"ORDER BY a.id DESC";
+
+	public List<FindMyFriendsArticlesResult> doFind(Long userId, Long articleId, Integer pageSize) {
+		List<Article> filteredArticles = entityManager.createQuery(SQL, Article.class)
+			.setParameter("userId", userId)
+			.setParameter("articleId", articleId)
+			.setMaxResults(pageSize)
+			.getResultList();
+
+		return filteredArticles.stream()
+			.map(this::toDto)
+			.collect(Collectors.toList());
+	}
+
+	private FindMyFriendsArticlesResult toDto(Article article) {
+		UserProfileDto userProfileDto = UserProfileDto.build(article.getUser());
+		FriendArticleDto friendArticleDto = createFriendArticleDto(article);
+
+		return new FindMyFriendsArticlesResult(userProfileDto, friendArticleDto);
+	}
+
+	private FriendArticleDto createFriendArticleDto(Article article) {
+		String contentsPreview = getContentsPreview(article.getContents());
+		String thumbnailImageUrl = getFirstImageUrl(article.getArticleImages());
+
+		return new FriendArticleDto(TsidUtil.toString(article.getId()),
+			article.getCreatedYear(),
+			article.getCreatedTerm(),
+			contentsPreview,
+			thumbnailImageUrl);
+	}
+
+	private String getFirstImageUrl(List<ArticleImage> images) {
+		return images.stream()
+			.min(Comparator.comparingInt(ArticleImage::getSequence))
+			.map(ArticleImage::getUrl)
+			.orElse(null);
+	}
+
+	private String getContentsPreview(String contents) {
+		if (contents == null) {
+			return "";
+		}
+		int previewLength = Math.min(contents.length(), 150);
+		return contents.substring(0, previewLength);
+	}
+}


### PR DESCRIPTION
## 📟 연결된 이슈
- close #57

## 👷 작업한 내용
- no offset 페이징 방식의 친구 기록장 목록 조회 기능 구현

## 🚨 참고 사항
- TSID는 시간 순으로 정렬된 값이기 때문에, 이를 이용하여 쿼리를 작성했습니다. 
- 요청 파라미터
  - size : 페이지 크기, 미지정 시 기본 10
  - lastId :  첫 요청 시 생략, 최근 조회 페이지의 마지막 기록장의 Id
