### PR TITLE
feat: 소셜 로그인 시, 회원가입 여부를 응답하는 헤더 추가

### DIFF
--- a/src/main/java/today/seasoning/seasoning/user/controller/OauthController.java
+++ b/src/main/java/today/seasoning/seasoning/user/controller/OauthController.java
@@ -6,6 +6,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import today.seasoning.seasoning.user.dto.LoginResultDto;
 import today.seasoning.seasoning.user.service.KakaoLoginService;
 
 @RestController
@@ -18,10 +19,11 @@ public class OauthController {
 	@GetMapping("/kakao/login")
 	public ResponseEntity<Void> kakaoLogin(@RequestParam("code") String authCode) {
 
-		String token = kakaoLoginService.handleKakaoLogin(authCode);
+		LoginResultDto loginResult = kakaoLoginService.handleKakaoLogin(authCode);
 
 		return ResponseEntity.ok()
-			.header("Authorization", token)
+			.header("Authorization", loginResult.getToken())
+			.header("Is-First", String.valueOf(loginResult.isNewUser()))
 			.build();
 	}
 }

--- a/src/main/java/today/seasoning/seasoning/user/dto/LoginResultDto.java
+++ b/src/main/java/today/seasoning/seasoning/user/dto/LoginResultDto.java
@@ -1,0 +1,15 @@
+package today.seasoning.seasoning.user.dto;
+
+import lombok.Getter;
+
+@Getter
+public class LoginResultDto {
+
+	private final String token;
+	private final boolean isNewUser;
+
+	public LoginResultDto(String token, boolean isNewUser) {
+		this.token = token;
+		this.isNewUser = isNewUser;
+	}
+}


### PR DESCRIPTION
## 📟 연결된 이슈
- close #60
 
## 👷 작업한 내용
- 회원가입 여부에 따라 클라이언트에서 리다이렉트 주소가 다르므로, 이를 구분하기 위해 관련 헤더 추가