### PR TITLE
CORS 설정 오류 해결

### DIFF
--- a/src/main/java/today/seasoning/seasoning/common/config/CorsConfig.java
+++ b/src/main/java/today/seasoning/seasoning/common/config/CorsConfig.java
@@ -13,7 +13,10 @@ public class CorsConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
-        config.setAllowedOrigins(List.of("https://alzzaipo.com", "http://localhost:3000"));
+        config.setAllowedOrigins(List.of(
+            "https://seasoning.today",
+            "https://seasoning.today:443",
+            "http://localhost:3000"));
         config.addAllowedMethod("*");
         config.addAllowedHeader("*");
         config.setAllowCredentials(true);


### PR DESCRIPTION
## 📟 연결된 이슈
- close #63 

## 👷 작업한 내용
- CORS 설정에 잘못된 도메인을 입력하여 이를 정정