### PR TITLE
이미지 저장용 S3 버킷에 CDN 적용

### DIFF
--- a/src/main/java/today/seasoning/seasoning/common/aws/S3Service.java
+++ b/src/main/java/today/seasoning/seasoning/common/aws/S3Service.java
@@ -18,7 +18,10 @@ public class S3Service {
 	private final AmazonS3 amazonS3;
 
 	@Value("${cloud.aws.s3.bucket}")
-	private String bucket;
+	private String s3BucketName;
+
+	@Value("${cloud.aws.cloudfront.distribution.url}")
+	private String cloudfrontUrl;
 
 	public String uploadFile(MultipartFile multipartFile, String filename) {
 		ObjectMetadata metadata = new ObjectMetadata();
@@ -26,8 +29,8 @@ public class S3Service {
 		metadata.setContentType(multipartFile.getContentType());
 
 		try {
-			amazonS3.putObject(bucket, filename, multipartFile.getInputStream(), metadata);
-			return amazonS3.getUrl(bucket, filename).toString();
+			amazonS3.putObject(s3BucketName, filename, multipartFile.getInputStream(), metadata);
+			return cloudfrontUrl.concat(filename);
 		} catch (Exception e) {
 			log.error("Uploading File Failed : {} - {}", filename, e.getMessage());
 			throw new CustomException(HttpStatus.INTERNAL_SERVER_ERROR, "파일 업로드 실패");
@@ -36,7 +39,7 @@ public class S3Service {
 
 	public void deleteFile(String filename) {
 		try {
-			amazonS3.deleteObject(bucket, filename);
+			amazonS3.deleteObject(s3BucketName, filename);
 		} catch (Exception e) {
 			log.error("Deleting File Failed : {} - {}", filename, e.getMessage());
 		}


### PR DESCRIPTION
## 📟 연결된 이슈
- close #65 
## 👷 작업한 내용
- Amazon Cloudfront를 활용하여 이미지 저장용 S3 버킷을 엣지 로케이션에 배포
- 이미지 조회 시 캐싱이 적용되도록 url을 Cloudfront 배포 주소로 변경
- S3 버킷 Private 전환 : 클라이언트는 S3 버킷이 아닌 Cloudfront에 접근하고, Cloudfront는 Origin Access Control 방식으로 원본에 접근하기 때문에 S3 버킷은 더 이상 Public일 필요가 없음
